### PR TITLE
WebSocket drawing frontend integration peer to peer drawing

### DIFF
--- a/apps/web/components/Canvas.tsx
+++ b/apps/web/components/Canvas.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useEffect, useRef } from "react";
+import { initDraw } from "../draw";
+
+interface CanvasProps {
+    messages: { message: string }[];
+    socket: WebSocket;
+    roomId:string
+  }
+
+export const Canvas = ({ messages, socket,roomId }: CanvasProps) => {
+      const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      initDraw(canvasRef.current,messages,socket,roomId);
+    }
+  }, [messages,socket,roomId]);
+
+    return   <div className="flex w-full max-w-7xl mx-auto p-8 space-x-8">
+    <div className="flex-1 relative z-10">
+      <canvas
+        ref={canvasRef}
+        width={800}
+        height={500}
+        className="w-full h-full bg-gray-800/50 backdrop-blur-sm rounded-lg shadow-xl border border-gray-700"
+      />
+    </div>
+  </div>
+}

--- a/apps/web/components/ChatRoomClient.tsx
+++ b/apps/web/components/ChatRoomClient.tsx
@@ -1,10 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect,useState } from "react";
 import { useSocket } from "../hooks/useSocket";
 import { GlowEffect1 } from "./ui/GlowEffect1";
-import { initDraw } from "../draw";
+import { Canvas } from "./Canvas";
+import Loading from "./Loading";
+
 
 export function ChatRoomClient({
   messages = [],
@@ -15,7 +16,6 @@ export function ChatRoomClient({
 }) {
   const [chats, setChats] = useState(messages);
   const { socket, loading } = useSocket();
-  const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
     if (socket && socket.readyState === WebSocket.OPEN && !loading) {
@@ -46,26 +46,14 @@ export function ChatRoomClient({
     };
   }, [socket, loading, id]);
 
-  useEffect(() => {
-    if (canvasRef.current) {
-      initDraw(canvasRef.current);
-    }
-  }, []);
+  if (!socket || loading || socket.readyState !== WebSocket.OPEN) {
+    return <div><Loading/></div>;
+  }
 
   return (
     <div className="min-h-screen flex justify-center items-center bg-gradient-to-br from-gray-900 to-black relative overflow-hidden">
       <GlowEffect1 />
-
-      <div className="flex w-full max-w-7xl mx-auto p-8 space-x-8">
-        <div className="flex-1 relative z-10">
-          <canvas
-            ref={canvasRef}
-            width={800}
-            height={500}
-            className="w-full h-full bg-gray-800/50 backdrop-blur-sm rounded-lg shadow-xl border border-gray-700"
-          />
-        </div>
-      </div>
+      <Canvas messages={chats} socket={socket} roomId={id}/>
     </div>
   );
 }

--- a/apps/web/components/Loading.tsx
+++ b/apps/web/components/Loading.tsx
@@ -1,0 +1,21 @@
+// Loading.tsx
+"use client";
+
+import React from "react";
+import Spinner from "./Spinner";
+import { GlowEffect1 } from "./ui/GlowEffect1";
+
+export const Loading = () => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-gray-900 to-black space-y-6">
+      {/* A subtle glow effect in the background */}
+      <GlowEffect1 />
+      {/* The spinner */}
+      <Spinner />
+      {/* Loading message */}
+      <p className="text-xl text-white">Loading, please wait...</p>
+    </div>
+  );
+};
+
+export default Loading;

--- a/apps/web/components/Spinner.tsx
+++ b/apps/web/components/Spinner.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+
+export const Spinner = () => {
+  return (
+    <div className="relative flex items-center justify-center">
+      {/* Outer static ring */}
+      <div className="w-16 h-16 border-4 border-gray-200 rounded-full" />
+      {/* Inner rotating ring */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    </div>
+  );
+};
+
+export default Spinner;


### PR DESCRIPTION
## WebSocket Drawing Frontend Integration for Peer-to-Peer Drawing

### Description
Our current drawing application lacks real-time collaborative drawing support. Users in the same drawing room should be able to see each other’s drawing events immediately. This issue proposes integrating WebSocket communication into the frontend to enable peer-to-peer drawing.

### Goals
- Enable real-time drawing synchronization across multiple clients.
- Ensure drawing events (e.g., `mousedown`, `mousemove`, `mouseup`) are broadcast over WebSockets.
- Use a consistent JSON structure for sending and receiving drawing shapes.
- Persist the drawing state so that shapes stored in the database are rendered on refresh.

### Proposed Changes
- Update the drawing canvas to send drawing events via WebSocket.
- Refactor the JSON message format so that shape data is sent directly (or is properly unwrapped) to avoid parsing issues.
- Replace or complement overwriting of `socket.onmessage` with `socket.addEventListener("message", …)` to allow multiple handlers (for chat and canvas updates).
- Ensure that drawing events are correctly captured and rendered in real time for all connected clients.

### Tasks
- [x] Implement WebSocket communication in the frontend to broadcast drawing events.
- [x] Ensure real-time updates by correctly handling incoming WebSocket messages.
- [x] Use a structured JSON format for sending and receiving drawing data.
- [x] Implement state persistence so that users see the previous drawings upon refresh.
- [x] Optimize event handling to prevent redundant updates or performance issues.

### Additional Context
Any suggestions or improvements are welcome! Feel free to contribute with ideas on handling edge cases like network lag, undo/redo functionality, or optimizing performance for large-scale drawings.

---

## Pull Request: WebSocket Drawing Frontend Integration for Peer-to-Peer Drawing

### Overview
This PR implements real-time collaborative drawing by integrating WebSocket support into the drawing frontend. Users in the same room will now see each other's drawing events as they happen, and shapes are persisted so that they are reloaded correctly on refresh.

### Key Changes

#### Drawing Events over WebSocket
- Updated canvas event listeners (`mousedown`, `mousemove`, `mouseup`) to broadcast drawing data via WebSocket.
- The JSON payload now sends the shape data directly (or extracts it correctly) so that incoming messages render as expected.

#### Consistent JSON Structure
- Adjusted the JSON message structure to avoid extra wrapping of shape data.
- Both the sender and receiver now agree on the shape format, which resolves issues where shapes were not rendered properly.

#### Robust WebSocket Handling
- Replaced the single assignment to `socket.onmessage` with `socket.addEventListener("message", …)` where needed.
- Allows multiple components (e.g., chat updates and canvas drawing) to process incoming messages without interference.

#### Persistence of Drawings
- Refined logic for restoring existing shapes from the database on refresh.
- Ensures that all saved drawing data is correctly parsed and rendered on the canvas.

### Testing Instructions

#### Peer-to-Peer Drawing
1. Open two (or more) browser windows.
2. Join the same drawing room.
3. Draw on one window and verify that the drawing appears in real time on the other windows.

#### Persistence on Refresh
1. Draw several shapes.
2. Refresh the browser.
3. Confirm that the shapes stored in the database are loaded and rendered correctly.

#### Message Handling
- Verify that chat messages and drawing events are both handled correctly and do not overwrite each other.

### Closes
Closes #15 (replace with the actual issue number once created).

